### PR TITLE
Fix AggregateRoot

### DIFF
--- a/src/PackIT.Shared.Abstractions/Domain/AggregateRoot.cs
+++ b/src/PackIT.Shared.Abstractions/Domain/AggregateRoot.cs
@@ -18,10 +18,9 @@ namespace PackIT.Shared.Abstractions.Domain
             {
                 Version++;
                 _versionIncremented = true;
-
-
-                _events.Add(@event);
             }
+            
+            _events.Add(@event);
         }
 
         public void ClearEvents() => _events.Clear();    


### PR DESCRIPTION
Increment AggregateRoot version when there are no previous events, but add new domain events even if there are existing ones.